### PR TITLE
Make project ID input disabled

### DIFF
--- a/ui/templates/project-list.html
+++ b/ui/templates/project-list.html
@@ -41,7 +41,7 @@
             <div class="col-md-2">
                 <div class="form-group">
                     <label for="project_id" class="sr-only">Project</label>
-                    <input type="text" class="form-control" id="project_id" name="project_id" placeholder="Project ID" required readonly>
+                    <input type="text" class="form-control" id="project_id" name="project_id" placeholder="Project ID" required readonly disabled>
                     <div class="invalid-feedback">Please provide a valid project id.</div>
                 </div>
             </div>


### PR DESCRIPTION
The project ID fields should be disabled (not just readonly) so the user cannot select it