### PR TITLE
in upload modal, display asset being uploaded into

### DIFF
--- a/ui/templates/asset-list.html
+++ b/ui/templates/asset-list.html
@@ -120,7 +120,7 @@
                             <i class="far fa-list-alt"></i>
                         </button>
                         <button type="button" class="btn btn-outline-primary" data-toggle="tooltip" data-placement="top" title="Upload into asset"
-                                onclick="showUploadModal('/api/store/{{ store_id }}/project/{{ project_id }}/asset/{{ asset.name }}/upload', false)">
+                                onclick="showUploadModal('/api/store/{{ store_id }}/project/{{ project_id }}/asset/{{ asset.name }}/upload', false, '{{ asset.name }}')">
                             <i class="fas fa-upload"></i>
                         </button>
                         <button class="btn btn-outline-primary" type="button" data-toggle="tooltip" data-placement="top" title="Process asset"

--- a/ui/templates/dialogs/upload-asset-dialog.html
+++ b/ui/templates/dialogs/upload-asset-dialog.html
@@ -1,5 +1,5 @@
 <script>
-    function showUploadModal(uploadUrl, multiUpload) {
+    function showUploadModal(uploadUrl, multiUpload, assetName) {
         const container = $("#upload-asset-container");
 
         container.empty();
@@ -17,6 +17,12 @@
             }
         });
 
+        let title = "Upload assets";
+        if (assetName){
+            title = "Upload into asset " + assetName;
+        }
+        document.getElementById('assetUploadModalLabel').innerText = title;
+
         const modal = $("#uploadAssetDialog");
         modal.on('hidden.bs.modal', function () {
             location.reload();
@@ -29,7 +35,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">Upload assets</h5>
+                <h5 class="modal-title" id="assetUploadModalLabel">Upload assets</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/ui/templates/dialogs/upload-asset-dialog.html
+++ b/ui/templates/dialogs/upload-asset-dialog.html
@@ -19,9 +19,9 @@
 
         let title = "Upload assets";
         if (assetName){
-            title = "Upload into asset " + assetName;
+            title = `Upload into asset <span class="badge badge-primary">${assetName}</span>`;
         }
-        document.getElementById('assetUploadModalLabel').innerText = title;
+        $('#assetUploadModalLabel').html(title);
 
         const modal = $("#uploadAssetDialog");
         modal.on('hidden.bs.modal', function () {


### PR DESCRIPTION
This ensures that a user knows where files they drag into the asset upload modal will end up, and helps to prevent errors due to clicking the wrong upload button.